### PR TITLE
Updating timeout

### DIFF
--- a/lib/zencoder/http.rb
+++ b/lib/zencoder/http.rb
@@ -13,7 +13,7 @@ module Zencoder
 
     self.http_backend = NetHTTP
 
-    self.default_options = {:timeout => 10000,
+    self.default_options = {:timeout => 60000,
                             :headers => {'Accept'       => 'application/json',
                                          'Content-Type' => 'application/json',
                                          'User-Agent'   => "Zencoder-rb v#{Zencoder::GEM_VERSION}"}}


### PR DESCRIPTION
Update the default timeout from 10 seconds to 60 seconds, which is the actual value enforced at the service level.
