### PR TITLE
save the request, so it can be inspected in case it fails

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,7 @@ response.code         # => 200
 response.body         # => the JSON-parsed body or raw body if unparseable
 response.raw_body     # => the body pre-JSON-parsing
 response.raw_response # => the raw Net::HTTP or Typhoeus response (see below for how to use Typhoeus)
+response.request      # => the request object, you can inspect it if you need details on the request to debug it
 ```
 
 ### Parameters

--- a/lib/zencoder/http.rb
+++ b/lib/zencoder/http.rb
@@ -75,11 +75,15 @@ module Zencoder
       self.class.default_options
     end
 
+    def inspect
+      "#{method.to_s.upcase} #{url}\nOptions: " + options.inspect
+    end
 
   protected
 
     def process(http_response)
       response = Response.new
+      response.request = self
       response.code = http_response.code
 
       begin

--- a/lib/zencoder/http/net_http.rb
+++ b/lib/zencoder/http/net_http.rb
@@ -7,12 +7,12 @@ module Zencoder
       def initialize(method, url, options)
         @method          = method
         @url             = url
-        @body            = options.delete(:body)
-        @params          = options.delete(:params)
-        @headers         = options.delete(:headers)
-        @timeout         = options.delete(:timeout)
-        @skip_ssl_verify = options.delete(:skip_ssl_verify)
-        @options         = options
+        @options         = options.dup
+        @body            = @options.delete(:body)
+        @params          = @options.delete(:params)
+        @headers         = @options.delete(:headers)
+        @timeout         = @options.delete(:timeout)
+        @skip_ssl_verify = @options.delete(:skip_ssl_verify)
       end
 
       def self.post(url, options={})

--- a/lib/zencoder/http/typhoeus.rb
+++ b/lib/zencoder/http/typhoeus.rb
@@ -19,6 +19,7 @@ module Zencoder
       end
 
       def self.perform(method, url, options={})
+        options = options.dup
         if options.delete(:skip_ssl_verify)
           options[:disable_ssl_peer_verification] = true
         end

--- a/lib/zencoder/response.rb
+++ b/lib/zencoder/response.rb
@@ -1,7 +1,7 @@
 module Zencoder
   class Response
 
-    attr_accessor :code, :body, :raw_body, :raw_response
+    attr_accessor :request, :code, :body, :raw_body, :raw_response
 
     def initialize(options={})
       options.each do |k, v|


### PR DESCRIPTION
I had an issue with Zencoder's API returning only "An unknown error has occurred. We have been notified.". With this patch it's possible to log and inspect the request in such cases.
