### PR TITLE
Adding the finish method to Job so it can finish live streaming jobs

### DIFF
--- a/lib/zencoder/job.rb
+++ b/lib/zencoder/job.rb
@@ -30,5 +30,9 @@ module Zencoder
       put("/jobs/#{job_id}/cancel", nil, options)
     end
 
+    def self.finish(job_id, options={})
+      put("/jobs/#{job_id}/finish", nil, options)
+    end
+
   end
 end

--- a/test/zencoder/job_test.rb
+++ b/test/zencoder/job_test.rb
@@ -101,5 +101,17 @@ class Zencoder::JobTest < Test::Unit::TestCase
       end
     end
 
+    context ".finish" do
+      setup do
+        @job_id = 1
+        @url = "#{Zencoder.base_url}/jobs/#{@job_id}/finish"
+      end
+
+      should "PUT the correct url and return a response" do
+        Zencoder::HTTP.stubs(:put).with(@url, nil, :headers => {"Zencoder-Api-Key" => @api_key}).returns(Zencoder::Response.new)
+        assert_equal Zencoder::Response, Zencoder::Job.finish(1, :api_key => @api_key).class
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This gem doesn't yet has the ability to finish live stream jobs. I came across the necessity a few days ago, so I'd though I'd help and patch things up. Hope it's alright.
